### PR TITLE
Move pickled credentials to variable file

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -29,8 +29,9 @@ from google.auth.transport.requests import Request
 class Authentication:
     def __init__(self, youtube=False, email=False, use_pickled_credentials=False):
         # Setup API clients
-        if not "SUPERMINISTREAM_AUTH_FILE" in os.environ:
-            print("You must set $SUPERMINISTREAM_AUTH_FILE to the json file containing your authentication credentials")
+
+        if not "SUPERMINISTREAM_AUTH_FILE" in os.environ or not "YOUTUBE_AUTH_PICKLE_FILE" in os.environ:
+            print("You must set $SUPERMINISTREAM_AUTH_FILE to the json file containing your authentication credentials and $YOUTUBE_AUTH_PICKLE_FILE to the Youtube pickled auth file")
             sys.exit(1)
 
         auth_file = os.environ["SUPERMINISTREAM_AUTH_FILE"]
@@ -60,7 +61,7 @@ class Authentication:
             "https://www.googleapis.com/auth/youtube.readonly",
             "https://www.googleapis.com/auth/youtube.force-ssl"]
 
-        pickle_file = "youtube_creds.pickle"
+        pickle_file = os.environ["YOUTUBE_AUTH_PICKLE_FILE"]
         credentials = None
         if use_pickled_credentials and os.path.exists(pickle_file):
             with open(pickle_file, "rb") as f:

--- a/core/auth.py
+++ b/core/auth.py
@@ -29,7 +29,6 @@ from google.auth.transport.requests import Request
 class Authentication:
     def __init__(self, youtube=False, email=False, use_pickled_credentials=False):
         # Setup API clients
-
         if not "SUPERMINISTREAM_AUTH_FILE" in os.environ or not "YOUTUBE_AUTH_PICKLE_FILE" in os.environ:
             print("You must set $SUPERMINISTREAM_AUTH_FILE to the json file containing your authentication credentials and $YOUTUBE_AUTH_PICKLE_FILE to the Youtube pickled auth file")
             sys.exit(1)


### PR DESCRIPTION
If you got your scripts in a shared drive (e.g. google drive), you may not want to have the pickled credentials stored in the cloud.